### PR TITLE
feat: exports now work

### DIFF
--- a/src/layer_preview.js
+++ b/src/layer_preview.js
@@ -47,6 +47,9 @@ const LAYOUT = {
 }
 
 function LayerToPreview(image, variant = 'classic') {
+  // exports a blob url
+  image.convertToBlob().then(function (result) {localStorage.setItem('skinRef', URL.createObjectURL(result))})
+  
   const canvas = new OffscreenCanvas(36, 32);
   const ctx = canvas.getContext('2d');
 
@@ -57,7 +60,9 @@ function LayerToPreview(image, variant = 'classic') {
     segment.uv.forEach(area => {
       const from = uvmap[area];
       const to = segment.coordinates;
-      ctx.drawImage(image, ...from, ...to, from[2], from[3])
+      ctx.drawImage(image, ...from, ...to, from[2], from[3],
+                    image, 0, 0, canvas.width, canvas.height
+        )
     })
   })
 


### PR DESCRIPTION
the current method for exporting skins is a little half-baked and may affect performance for lower-end devices but i don't really see a huge problem with it due to the fact it simply uses a similar method to the one used in the older editor